### PR TITLE
Added User-Agent request header

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 import websocket
-from urllib.request import urlopen
+from urllib.request import urlopen, Request
 import json
 import subprocess
 import os.path
@@ -37,12 +37,15 @@ def get_picture(appid):
     if os.path.isfile(path):
         return imgPath
     else:
-        r = json.loads(urlopen("https://{}/application?token={}".format(domain, token)).read())
+        req = Request("https://{}/application?token={}".format(domain, token))
+        req.add_header("User-Agent", "Mozilla/5.0")
+        r = json.loads(urlopen(req).read())
         for i in r:
             if i['id'] == appid:
                 with open(imgPath, "wb") as f:
-                    url = urlopen("https://{}/{}?token={}".format(domain, i['image'], token))
-                    f.write(url.read())
+                    req = Request("https://{}/{}?token={}".format(domain, i['image'], token))
+                    req.add_header("User-Agent", "Mozilla/5.0")
+                    f.write(urlopen(req).read())
         return imgPath
 
 def send_notification(message):


### PR DESCRIPTION
Hi, I've tried the script and found it quite useful. However, it's unable to fetch the app icon from my gotify server deployed behind an nginx proxy. It returns 403 forbidden whenever a message is received (see below, with my domain anonymized). 

I found that it's due to the lack of the `User-Agent` request header, so I created this pull request to fix that issue.

<details>
<summary>Error message</summary>

```python
{"id":32,"appid":4,"message":"test 5","title":"Alert","priority":7,"date":"2021-02-06T17:16:07.90591304+08:00"}

--> XXXXXXX.com/gotify C7jyVxCaef_SaL0
error from callback <function on_message at 0x7fddb9c52940>: HTTP Error 403: Forbidden
  File "/usr/lib/python3.9/site-packages/websocket/_app.py", line 346, in _callback
    callback(self, *args)
  File "/usr/lib/gotify-dunst/main.py", line 60, in on_message
    send_notification(message)
  File "/usr/lib/gotify-dunst/main.py", line 54, in send_notification
    subprocess.Popen(['notify-send', m['title'], m['message'], "-u", "normal", "-i", get_picture(m['appid'])])
  File "/usr/lib/gotify-dunst/main.py", line 41, in get_picture
    r = json.loads(urlopen("https://{}/application?token={}".format(domain, token)).read())
  File "/usr/lib/python3.9/urllib/request.py", line 214, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.9/urllib/request.py", line 523, in open
    response = meth(req, response)
  File "/usr/lib/python3.9/urllib/request.py", line 632, in http_response
    response = self.parent.error(
  File "/usr/lib/python3.9/urllib/request.py", line 561, in error
    return self._call_chain(*args)
  File "/usr/lib/python3.9/urllib/request.py", line 494, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.9/urllib/request.py", line 641, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
```

</details>
