### PR TITLE
option to support unsecure protocols

### DIFF
--- a/gotify-dunst.conf
+++ b/gotify-dunst.conf
@@ -1,3 +1,4 @@
 [server]
+ssl=true
 domain=push.example.com
 token=C2Un.92TZBzsukg


### PR DESCRIPTION
On my first usage I was quite puzzled why the notifications didn't work. My gotify service is running in my local network so the issue was the `https` and `wss` protocols.

I added a option `ssl` to the config to enable/disable secure protocols for http and websocket.