### PR TITLE
Disable tracing for websocket

### DIFF
--- a/main.py
+++ b/main.py
@@ -71,7 +71,6 @@ def on_message(ws, message):
     send_notification(message)
 
 if __name__ == "__main__":
-    websocket.enableTrace(True)
     if ssl:
         protocol = 'wss'
     else:


### PR DESCRIPTION
Sorry that I had to create another PR; I didn't notcie the call to `enableTrace` before.

But this should really get rid of all the gratuitious log messages.